### PR TITLE
Updated "Release" action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,42 +3,52 @@ name: Publish Python Package
 on:
   release:
     types: [published]
-
 jobs:
-  release:
+  build:
+    name: Build wheels with cibuildwheel
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9, 3.10, 3.11, 3.12]
-    runs-on: ${{ matrix.os }}
-
+        os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - name: Checkout source code
+        uses: actions/checkout@v3
 
-      - name: Set up Python
+      - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: "3.11" # 3.x is technically not supported by the runner as per https://github.com/actions/setup-python/blob/55aad42e4674b58b2b2fb7d8e7552402d922b4e7/src/utils.ts#L107
 
-      - name: Install build tools
+      - name: Install cibuildwheel
         run: |
           python -m pip install --upgrade pip
-          python -m pip install build twine
+          python -m pip install cibuildwheel
 
-      - name: Build package
+      - name: Build wheels
         run: |
-          python -m build --wheel --outdir dist
-
-      - name: Publish to PyPI
-        run: |
-          python -m pip install twine
-          python -m twine upload dist/*.whl --verbose
+          cibuildwheel --output-dir dist
         env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-
-      - name: Test installation (optional)
-        run: |
-          pip install dist/*.whl
-          python -c "import bigo"
+          CIBW_BUILD: cp3{9,10,11,12}-*
+          CIBW_SKIP: pp*,cp38*
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: dist/
+  
+  release:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: dist
+          path: dist
+      - name: Upload wheels to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN  }}


### PR DESCRIPTION
We were dealing with some problems with twine uploads of Linux wheels, so rather than trying to deal with the intricacies of changing the twine build, we decided to see what current publishing pipelines looked like in Github Actions. This led to two repos containing actions that pypa wrote and maintains

- [cibuildwheel](https://github.com/pypa/cibuildwheel) is apparently the specific solution to the error we were seeing-- the error `unsupported platform tag 'linux_x86_64'.` led me to [this stack overflow post](https://stackoverflow.com/questions/59451069/binary-wheel-cant-be-uploaded-on-pypi-using-twine) which suggested `cibuildwheel`. In the post, it also has links to the relevant PEPs.
- [action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish) was used in the example workflow of cibuildwheel, so I added it to this updated pipeline. It seems to be what pypa recommends, but it also has some additional security features that may prove problematic. 